### PR TITLE
Revert "Revert "fix "cannot locate symbol "_ZN7android16MediaBufferGr…

### DIFF
--- a/include/media/stagefright/MediaBufferGroup.h
+++ b/include/media/stagefright/MediaBufferGroup.h
@@ -51,7 +51,10 @@ public:
     // If requestedSize is > 0, the returned MediaBuffer should have buffer
     // size of at least requstedSize.
     status_t acquire_buffer(
-            MediaBuffer **buffer, bool nonBlocking = false, size_t requestedSize = 0);
+            MediaBuffer **buffer, bool nonBlocking, size_t requestedSize);
+
+    status_t acquire_buffer(MediaBuffer **buffer);
+    status_t acquire_buffer(MediaBuffer **buffer, bool nonBlocking);
 
     size_t buffers() const { return mBuffers.size(); }
 

--- a/media/libstagefright/foundation/MediaBufferGroup.cpp
+++ b/media/libstagefright/foundation/MediaBufferGroup.cpp
@@ -183,6 +183,16 @@ status_t MediaBufferGroup::acquire_buffer(
     // Never gets here.
 }
 
+status_t MediaBufferGroup::acquire_buffer(
+        MediaBuffer **out) {
+    return acquire_buffer(out, false, 0);
+}
+
+status_t MediaBufferGroup::acquire_buffer(
+        MediaBuffer **out, bool nonBlocking) {
+    return acquire_buffer(out, nonBlocking, 0);
+}
+
 void MediaBufferGroup::signalBufferReturned(MediaBuffer *) {
     mCondition.signal();
 }


### PR DESCRIPTION
…oup14acquire_bufferEPPNS_11MediaBufferE" referenced by libwvm.so"""

This reverts commit b278a938c3774d0bb13eeea7096665a9f14436bc.